### PR TITLE
Users may be instance admins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:
-    - db/seeds.rb
     - bin/bundle
     - lib/tasks/cucumber.rake
 

--- a/db/migrate/20171217191956_add_instance_admin_flag_to_users.rb
+++ b/db/migrate/20171217191956_add_instance_admin_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddInstanceAdminFlagToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :instance_admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_171_216_031_536) do
+ActiveRecord::Schema.define(version: 20_171_217_191_956) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pgcrypto"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20_171_216_031_536) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "instance_admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,13 @@
 # This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+# The data can then be loaded with the rails db:seed command (or created alongside the database with
+# db:setup).
 #
 # Examples:
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+raise "Probably shouldn't run this on production..." if Rails.env.production?
+
+User.create_with(password: "password", instance_admin: true)
+    .find_or_create_by(email: "admin@example.com")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,15 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#instance_admin?" do
+    it "defaults to false" do
+      user = User.new
+      expect(user).not_to be_instance_admin
+    end
+
+    it "may be updated to true" do
+      user = User.new(instance_admin: true)
+      expect(user).to be_instance_admin
+    end
+  end
 end


### PR DESCRIPTION
As we build out more features, being able to expose functionality
based upon whether someone is an instance admin will be useful.

This brings in the ability to be set as an admin via a boolean, we may
eventually need to do fancy things like group ownerships and different
levels or kinds of admins, but that seems like something we should be
able to evolve towards without too much difficulty

Resolves #37