### PR TITLE
Make the home page public and the new project page private

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,6 @@
 # Home page for the application
 class DashboardController < ApplicationController
   expose :projects, -> { Project.approved }
-  before_action :authenticate_user!
 
   def index; end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,7 @@
 # Exposes CRUD actions for projects
 class ProjectsController < ApplicationController
+  before_action :authenticate_user!
+
   expose :project, scope: -> { current_user.projects }
   def new; end
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,3 @@
-<%= current_user.email %>
-
 <%- projects.each do |project| %>
   <div class="project">
     <h2 class="title"><%= project.title %></h2>

--- a/features/sign_in_and_sign_up.feature
+++ b/features/sign_in_and_sign_up.feature
@@ -1,30 +1,30 @@
-Feature: User login and registration
+Feature: Sign in and Sign up
 
   Scenario: User can sign up
-    When I register with the email "unique-email@example.com" and the password "password"
+    When I sign up with the email "unique-email@example.com" and the password "password"
     Then I should not see any errors
-    And I should be logged in as "unique-email@example.com"
+    And I should be signed in as "unique-email@example.com"
 
   Scenario: User cannot sign up with an email address that already exists
     Given there is already a user with the email "taken-email@example.com"
-    When I register with the email "taken-email@example.com" and the password "password"
+    When I sign up with the email "taken-email@example.com" and the password "password"
     Then I should see an error saying that the email has been taken
-    And I should not be logged in
+    And I should not be signed in
 
-  Scenario: User must provide email and password when registering
-    When I register with the email "" and the password ""
+  Scenario: User must provide email and password when signing up
+    When I sign up with the email "" and the password ""
     Then I should see an error saying that an email is required
     And I should see an error saying that a password is required
     And I should see an error saying that a password confirmation is required
 
   Scenario: User can sign in to an existing account
     Given there is already a user with the email "taken-email@example.com" and the password "password"
-    When I log in as "taken-email@example.com" using the password "password"
+    When I sign in as "taken-email@example.com" using the password "password"
     Then I should not see any errors
-    And I should be logged in as "taken-email@example.com"
+    And I should be signed in as "taken-email@example.com"
 
   Scenario: User can sign out
     Given I am signed in
-    When I log out
-    Then I should not be logged in
+    When I sign out
+    Then I should not be signed in
 

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1,4 +1,5 @@
 Given("I am not signed in") do
+  # This step definition intentionally left blank, as being not-signed in is the default
 end
 
 Given("I am signed in") do

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1,6 +1,9 @@
+Given("I am not signed in") do
+end
+
 Given("I am signed in") do
   user = create(:user)
-  app.login_as(user: user)
+  app.sign_in_as(user: user)
 end
 
 Given("there is already a user with the email {string}") do |email|
@@ -11,16 +14,20 @@ Given("there is already a user with the email {string} and the password {string}
   User.create(email: email, password: password)
 end
 
-When("I register with the email {string} and the password {string}") do |email, password|
-  app.register_as(email: email, password: password)
+When("I sign up with the email {string} and the password {string}") do |email, password|
+  app.sign_up_as(email: email, password: password)
 end
 
-When("I log in as {string} using the password {string}") do |email, password|
-  app.login_as(email: email, password: password)
+When("I sign in as {string} using the password {string}") do |email, password|
+  app.sign_in_as(email: email, password: password)
 end
 
-When("I log out") do
-  app.logout
+When("I sign out") do
+  app.sign_out
+end
+
+When("I begin to submit a project") do
+  app.visit(:new_project_page)
 end
 
 When("I submit a project titled {string} and summarized as {string}") do |title, summary|
@@ -32,12 +39,16 @@ When("the project titled {string} is approved") do |title|
   project.approve
 end
 
+Then("I am redirected to the sign in page") do
+  expect(app).to be_on(:sign_in_page)
+end
+
 Then("I should not see any errors") do
   expect(app).not_to be_showing_errors
 end
 
-Then("I should be logged in as {string}") do |email|
-  expect(app).to be_logged_in_as(email: email)
+Then("I should be signed in as {string}") do |email|
+  expect(app).to be_signed_in_as(email: email)
 end
 
 Then("I should see an error saying that the email has been taken") do
@@ -57,8 +68,8 @@ Then("I should see an error saying that a password confirmation is required") do
                                   "errors.messages.required")
 end
 
-Then("I should not be logged in") do
-  expect(app).not_to be_logged_in
+Then("I should not be signed in") do
+  expect(app).not_to be_signed_in
 end
 
 Then("there is not a public project titled {string} and summarized as {string}") do |title, _summary|
@@ -67,7 +78,7 @@ end
 
 Then("I am a member of the project titled {string}") do |title|
   project = Project.find_by(title: title)
-  expect(project.members).to include(app.logged_in_user)
+  expect(project.members).to include(app.current_user)
 end
 
 Then("there is a public project titled {string} and summarized as {string}") do |title, _summary|

--- a/features/submitting_a_project.feature
+++ b/features/submitting_a_project.feature
@@ -11,3 +11,9 @@ Feature: Submitting a project
     When the project titled "Space Unicorns" is approved
     Then there is a public project titled "Space Unicorns" and summarized as "Ride a space unicorn!"
     And I am a member of the project titled "Space Unicorns"
+
+
+ Scenario: Guests may not submit projects
+    Given I am not signed in
+    When I begin to submit a project
+    Then I am redirected to the sign in page

--- a/features/support/pages/sign_in_page.rb
+++ b/features/support/pages/sign_in_page.rb
@@ -1,6 +1,5 @@
-# Represents the page used to log in to the application
-# Encapsulates all login related functionality for feature tests
-class LoginPage < SitePrism::Page
+# Encapsulates sign in functionality for feature tests
+class SignInPage < SitePrism::Page
   set_url "/users/sign_in/"
 
   element :email_field, "input[name='user[email]']"

--- a/features/support/pages/sign_up_page.rb
+++ b/features/support/pages/sign_up_page.rb
@@ -1,6 +1,5 @@
-# Represents the page used to register for the application. Encapsulates all registration functionality for
-# feature tests.
-class RegistrationPage < SitePrism::Page
+# Encapsulates sign up functionality for feature tests
+class SignUpPage < SitePrism::Page
   set_url "/users/sign_up/"
 
   element :email_field, "input[name='user[email]']"


### PR DESCRIPTION
I noticed we don't have the new project page behind a login wall, but the home page was! Oops!


This swaps that around, and adds a test to make sure attempting to submit a project sends you to sign in.