### PR TITLE
Don't load coveralls in production

### DIFF
--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,4 +1,8 @@
-require "coveralls/rake/task"
-Coveralls::RakeTask.new
-desc "Runs the unit and feature tests and sends to coveralls"
-task default: [:spec, :cucumber, "coveralls:push"]
+begin
+  require "coveralls/rake/task"
+  Coveralls::RakeTask.new
+  desc "Runs the unit and feature tests and sends to coveralls"
+  task default: [:spec, :cucumber, "coveralls:push"]
+rescue LoadError
+  :this_is_fine
+end


### PR DESCRIPTION
The way I had organized the default rake task worked when using development mode, but not in production since coveralls (rightfully!) isn't installed in production.