### PR TITLE
Show feedback as a notice when approving or rejecting a project

### DIFF
--- a/app/controllers/project_approvals_controller.rb
+++ b/app/controllers/project_approvals_controller.rb
@@ -12,6 +12,7 @@ class ProjectApprovalsController < ModerationController
     end
 
     if project_approval.persisted?
+      flash[:notice] = t("approving_project.success_notification", project_title: pending_project.title)
       redirect_to pending_projects_path
     else
       render :new

--- a/app/controllers/project_rejections_controller.rb
+++ b/app/controllers/project_rejections_controller.rb
@@ -12,6 +12,7 @@ class ProjectRejectionsController < ModerationController
     end
 
     if project_rejection.persisted?
+      flash[:notice] = t("rejecting_project.success_notification", project_title: pending_project.title)
       redirect_to pending_projects_path
     else
       render :new

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,11 +4,17 @@ en:
       browse_projects: "Home"
       pending_projects: "Pending Projects"
       project_status_changes: "Moderator Activity Log"
+
+  cta:
+    submit_your_project_for_approval: "Submit your project"
+
   approving_project:
     begin: "Approve"
     reason_field: "Why do you think this project is a good fit for Nourish.Party?"
     cancel: "Cancel"
     complete: "Approve"
+    success_notification: "You have approved the project %{project_title}"
+
   my_projects:
     header: "My Projects"
     pending_projects_header: "Pending Projects"
@@ -20,9 +26,7 @@ en:
     reason_field: "Why do you think this project is not a good fit for Nourish.Party?"
     cancel: "Cancel"
     complete: "Reject"
-
-  cta:
-    submit_your_project_for_approval: "Submit your project"
+    success_notification: "You have rejected the project %{project_title}"
 
   stripe_connections:
     heading: "Process Payments via Stripe"

--- a/features/approving_a_project.feature
+++ b/features/approving_a_project.feature
@@ -7,7 +7,8 @@ Scenario: Admin approves a project
   Given a project is pending
   And I sign in as an instance admin
   When I approve the project
-  Then the project status changes log shows that I approved the project
+  Then I see a notice that I approved the project
+  And the project status changes log shows that I approved the project
   And the project is publicly available
   And the project is no longer pending
 

--- a/features/rejecting_a_project.feature
+++ b/features/rejecting_a_project.feature
@@ -7,7 +7,8 @@ Scenario: Admin rejects a project
   Given a project is pending
   And I sign in as an instance admin
   When I reject the project
-  Then the project status changes log shows that I rejected the project
+  Then I see a notice that I rejected the project
+  And the project status changes log shows that I rejected the project
   And the project is not publicly available
   And the project is no longer pending
 

--- a/features/step_definitions/project_steps.rb
+++ b/features/step_definitions/project_steps.rb
@@ -93,3 +93,9 @@ Then(/I can see the project in my projects as (approved|pending|rejected)/) do |
   app.visit(:my_projects_page)
   expect(app.current_page).to be_showing_project(app.project_under_test, status: status)
 end
+
+Then(/I see a notice that I (approved|rejected) the project$/) do |status|
+  i18n_path = status == "approved" ? "approving_project" : "rejecting_project"
+  expect(app).to be_showing_notice("#{i18n_path}.success_notification",
+                                   project_title: app.project_under_test.title)
+end

--- a/features/support/pages/app.rb
+++ b/features/support/pages/app.rb
@@ -84,6 +84,10 @@ class App
     page.click_on(I18n.t("devise.shared.links.sign_out"))
   end
 
+  def showing_notice?(translation, interpolations = {})
+    page.find('.notification.\--notice').has_text?(I18n.t(translation, interpolations))
+  end
+
   def showing_errors?
     page.has_css?(".error") || page.has_css?("#error_explanation")
   end


### PR DESCRIPTION
* Re-order en.yaml to be alphabetical except for `shared` at the top.