### PR TITLE
Allow multiple users and projects to be created in test factories

### DIFF
--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :project do
-    title "Title #{SecureRandom.uuid}"
-    summary "Summary #{SecureRandom.uuid}"
+    title { "Title #{SecureRandom.uuid}" }
+    summary { "Summary #{SecureRandom.uuid}" }
   end
 end

--- a/spec/factories/registered_user_factory.rb
+++ b/spec/factories/registered_user_factory.rb
@@ -1,13 +1,11 @@
 FactoryBot.define do
-  factory :registered_user do
-    email "user-#{SecureRandom.uuid}@example.com"
+  factory :registered_user, aliases: [:user] do
+    email { "user-#{SecureRandom.uuid}@example.com" }
     password "password"
 
     factory :instance_admin do
+      email { "instance-admin-#{SecureRandom.uuid}@example.com" }
       instance_admin true
-    end
-
-    factory :user do
     end
   end
 end


### PR DESCRIPTION
Turns out we had an accidental limitation where we weren't generating unique data when we thought we were in our factories. Oops!