### PR TITLE
Require users confirm their address before being allowed to sign in

### DIFF
--- a/app/models/registered_user.rb
+++ b/app/models/registered_user.rb
@@ -2,7 +2,7 @@
 class RegisteredUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :confirmable, :database_authenticatable, :lockable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :project_memberships, foreign_key: :member_id

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -9,9 +9,9 @@ Doorkeeper.configure do
 
   # If you want to restrict access to the web interface for adding oauth authorized applications,
   # you need to declare the block below.
-  #admin_authenticator do |routes|
+  # admin_authenticator do |routes|
   #  redirect_to(new_registered_user_session_url) unless current_resource_owner.instance_admin?
-  #end
+  # end
 
   # Authorization Code expiration time (default 10 minutes).
   # authorization_code_expires_in 10.minutes

--- a/db/migrate/20180104193230_add_owner_to_application.rb
+++ b/db/migrate/20180104193230_add_owner_to_application.rb
@@ -2,6 +2,6 @@ class AddOwnerToApplication < ActiveRecord::Migration[5.1]
   def change
     add_column :oauth_applications, :owner_id, :integer, null: true
     add_column :oauth_applications, :owner_type, :string, null: true
-    add_index :oauth_applications, [:owner_id, :owner_type]
+    add_index :oauth_applications, %i[owner_id owner_type]
   end
 end

--- a/db/migrate/20180105210226_add_confirmable_to_registered_users.rb
+++ b/db/migrate/20180105210226_add_confirmable_to_registered_users.rb
@@ -1,0 +1,19 @@
+class AddConfirmableToRegisteredUsers < ActiveRecord::Migration[5.1]
+  def change
+    change_table :registered_users do |t|
+      # Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      # Lockable
+      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+    end
+
+    add_index :registered_users, :confirmation_token,   unique: true
+    add_index :registered_users, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180104193230) do
-
+ActiveRecord::Schema.define(version: 20_180_105_210_226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pgcrypto"
@@ -55,7 +54,7 @@ ActiveRecord::Schema.define(version: 20180104193230) do
     t.datetime "updated_at", null: false
     t.integer "owner_id"
     t.string "owner_type"
-    t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
+    t.index %w[owner_id owner_type], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
@@ -99,8 +98,18 @@ ActiveRecord::Schema.define(version: 20180104193230) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "instance_admin", default: false
+    t.string "stripe_customer_id"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.index ["confirmation_token"], name: "index_registered_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_registered_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_registered_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_registered_users_on_unlock_token", unique: true
   end
 
   create_table "stripe_connections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,7 +98,6 @@ ActiveRecord::Schema.define(version: 20_180_105_210_226) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "instance_admin", default: false
-    t.string "stripe_customer_id"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"

--- a/features/sign_in_and_sign_up.feature
+++ b/features/sign_in_and_sign_up.feature
@@ -3,7 +3,8 @@ Feature: Sign in and Sign up
   Scenario: User can sign up
     When I sign up with the email "unique-email@example.com" and the password "password"
     Then I should not see any errors
-    And I should be signed in as "unique-email@example.com"
+    And I should not be signed in
+    And I should be asked to confirm my account
 
   Scenario: User cannot sign up with an email address that already exists
     Given there is already a user with the email "taken-email@example.com"

--- a/features/step_definitions/sign_in_and_sign_up_steps.rb
+++ b/features/step_definitions/sign_in_and_sign_up_steps.rb
@@ -3,13 +3,12 @@ Given("I am not signed in") do
 end
 
 Given("I am signed in") do
-  user = create(:user)
-  app.sign_in_as(user: user)
+  app.sign_in_as(user: create(:user))
 end
 
 Given(/^I sign in as (a|an) (user|instance admin|project creator|supporter)$/) do |_, user_type|
-  user_type = user_type.tr(" ", "_").downcase.to_sym
-  app.sign_in_as(user: create(user_type))
+  user = create(user_type.tr(" ", "_").downcase.to_sym)
+  app.sign_in_as(user: user)
 end
 
 Given("there is already a user with the email {string}") do |email|
@@ -59,4 +58,8 @@ end
 
 Then("I am redirected to the sign in page") do
   expect(app).to be_on(:sign_in_page)
+end
+
+Then("I should be asked to confirm my account") do
+  expect(page).to have_content(t("devise.registrations.signed_up_but_unconfirmed"))
 end

--- a/features/support/helper.rb
+++ b/features/support/helper.rb
@@ -19,6 +19,10 @@ module FeatureTestHelpers
   def current_page
     app.current_page
   end
+
+  def t(lookup, options = {})
+    I18n.t(lookup, options)
+  end
 end
 
 World(FeatureTestHelpers)

--- a/spec/factories/registered_user_factory.rb
+++ b/spec/factories/registered_user_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :registered_user, aliases: [:user] do
     email { "user-#{SecureRandom.uuid}@example.com" }
     password "password"
+    confirmed_at { Time.now }
 
     factory :instance_admin do
       email { "instance-admin-#{SecureRandom.uuid}@example.com" }


### PR DESCRIPTION
Stripe has strong feels about confirming email addresses as part of fraud detection and prevention. Mailgun has similar feels re: sending emails.

Since we're dealing with financial stuff, requiring confirmation before people can do things seems reasonable; and we can streamline the user interface if we decide there are some things we are OK with unconfirmed users doing later.