### PR TITLE
Tone down party references and direct folks to nourish.is

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at hello@nourish.party. All
+reported by contacting the project team at [hello@nourish.is](mailto: hello@nourish.is). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,35 @@
-## Contributing to Nourish.Party
-There are four main ways to contribute to Nourish.Party, and we are grateful for each and every contribution you choose to make.
+## Contributing to Nourish
+There are four main ways to contribute to Nourish, and we are grateful for each and every contribution you choose to make.
 
-1. Promoting and improving adoption of Nourish.Party.
-1. Setting up or supporting a Nourish.Party instance.
-1. Extending the Nourish.Party ecosystem by building add-ons and extensions.
-1. Improving the core Nourish.Party application.
+1. Promoting and improving adoption of Nourish.
+1. Setting up or supporting a Nourish instance.
+1. Extending the Nourish ecosystem by building add-ons and extensions.
+1. Improving the core Nourish application.
 
 
 To attempt a shared level of clarity the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-### Promoting and Improving Adoption of Nourish.Party
-At this time, we are unclear on how to best promote adoption of Nourish.Party. If you happen to have expertise in marketing open-source products, we'd love to hear from you! Drop us a line at [hello@nourish.party](mailto: hello@nourish.party).
+### Promoting and Improving Adoption of Nourish
+At this time, we are unclear on how to best promote adoption of Nourish. If you happen to have expertise in marketing open-source products, we'd love to hear from you! Drop us a line at [hello@nourish.is](mailto: hello@nourish.is).
 
-### Setting up or Supporting a Nourish.Party instance
-We intend to make setting up a Nourish.Party instance as painless as possible, however we are planning to do that by prioritizing a Heroku button type experience. If you have experience making one-click installs of applications on hosting control panels or work with cloud service providers, we'd love your help! Drop a line to [hello@nourish.party](mailto: hello@nourish.party).
+### Setting up or Supporting a Nourish instance
+We intend to make setting up a Nourish instance as painless as possible, however we are planning to do that by prioritizing a Heroku button type experience. If you have experience making one-click installs of applications on hosting control panels or work with cloud service providers, we'd love your help! Drop a line to [hello@nourish.is](mailto: hello@nourish.is).
 
-### Extending the Nourish.Party ecosystem
-Our goal is for Nourish.Party to plug directly into your existing distribution channels, from amazon stores to etsy to Discord to Slack. As you can imagine, that's quite a feat! If you'd like to get involved building an extension, we'd love for you to start building on our OAuth, REST, GraphQL, and Webhook APIs. (Which aren't designed, docuemnted, or built yet... BUT SOON).
+### Extending the Nourish ecosystem
+Our goal is for Nourish to plug directly into your existing distribution channels, from amazon stores to etsy to Discord to Slack. As you can imagine, that's quite a feat! If you'd like to get involved building an extension, we'd love for you to start building on our OAuth, REST, GraphQL, and Webhook APIs. (Which aren't designed, docuemnted, or built yet... BUT SOON).
 
-### Improving the core Nourish.Party application
+### Improving the core Nourish application
 Right now, there are four ways to contribute
 
-#### Providing Feedback to Nourish.Party Maintainers
-Nourish.Party is open-source, community built software. While we intend to place the user first, we sometimes fail to do so. One of the most valuable thing you can do to improve the Nourish.Party is to provide us with specific, actionable and detailed feedback. We're especially interested in hearing about:
+#### Providing Feedback to Nourish Maintainers
+Nourish is open-source, community built software. While we intend to place the user first, we sometimes fail to do so. One of the most valuable thing you can do to improve the Nourish is to provide us with specific, actionable and detailed feedback. We're especially interested in hearing about:
 
-* How Nourish.Party is (or is not!) helping you achieve your goals for financial independence as an independent creative or a small group of creatives.
+* How Nourish is (or is not!) helping you achieve your goals for financial independence as an independent creative or a small group of creatives.
 * Wins or bugs you experienced using Nourish as a supporter.
-* Gaps in our documentation, either as a Nourish.Party site host, add-on developer, or contributor to the core nourish.party platform.
-* Vulnerabilities or risks. Please report these to [security@nourish.party](mailto: security@nourish.party).
+* Gaps in our documentation, either as a Nourish site host, add-on developer, or contributor to the core nourish.is platform.
+* Vulnerabilities or risks. Please report these to [security@nourish.is](mailto: security@nourish.is).
 
-To provide feedback you *should* either create a ticket in our [issue tracker](https://github.com/wecohere/nourish.party/issues) or email [hello@nourish.party](mailto: hello@nourish.party).
+To provide feedback you *should* either create a ticket in our [issue tracker](https://github.com/wecohere/nourish.is/issues) or email [hello@nourish.is](mailto: hello@nourish.is).
 
 #### Contributing Patches
 Patches are very much welcome! From documentation improvements to bug fixes to features, we're grateful for any contributions you send our way. We strongly err on the side of merging patches, so long as the patch meets the following requirements:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The GPLv2 (or later) from the Free Software Foundation is the license that the Nourish Party software is
+The GPLv2 (or later) from the Free Software Foundation is the license that the Nourish software is
 under. Its text follows.
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# nourish.party
+# Nourish
 
 ![build status](https://travis-ci.org/wecohere/nourish.party.svg?branch=primary)
 [![Coverage Status](https://coveralls.io/repos/github/wecohere/nourish.party/badge.svg?branch=primary)](https://coveralls.io/github/wecohere/nourish.party?branch=primary)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2ec7c0159dafe8370ee7/maintainability)](https://codeclimate.com/github/wecohere/nourish.party/maintainability)
-Hello, and thanks for coming by!  This party is to celebrate and nourish creators and their communities.  Whether you're here to help us get set up, or here to enjoy the festivities, we're glad you're here.
+Hello, and thanks for coming by! Nourish aims to celebrate and support creators and their communities.  Whether you're here to help us get set up, or just to check out what's up, we're glad you're here.
 
 ## What is Nourish?
 Nourish is software that lets you receive and take subscriptions, and manage access to digital goodies based on subscription level.  It's open source software that is free for you to download, install, and use.  All costs and benefits are solely managed by you.  Please see the license for more details.
@@ -11,8 +11,8 @@ Nourish is software that lets you receive and take subscriptions, and manage acc
 ## How do I use it?
 There are two ways you can get started using Nourish:
 
-* You can join an existing Nourish instance and submit your project. For instance, [nourish.party](https://www.nourish.party) is hosting this project.
-* You can host your own! While we don't have super detailed setup instructions *just* yet, you can launch your own instance with your [Heroku](https://heroku.com) account. If you choose to host your own instance, you'll be responsible for security, hosting, maintenance, configuration, and moderating your community. Doesn't that sound fun!? Just click the big purple button below to start hosting your own Nourish Party!
+* You can join an existing Nourish instance and submit your project. For instance, [nourish.is](https://www.nourish.is) is hosting this project.
+* You can host your own! While we don't have super detailed setup instructions *just* yet, you can launch your own instance with your [Heroku](https://heroku.com) account. If you choose to host your own instance, you'll be responsible for security, hosting, maintenance, configuration, and moderating your community. Doesn't that sound fun!? Just click the big purple button below to start hosting your own Nourish!
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/wecohere/nourish.party/tree/primary&env[FORCE_SEED]=false)
 
@@ -25,6 +25,6 @@ Cohere (wecohere.com) is Betsy, Zee, and Jennifer.  They have an annual end-of-y
 * Dash for making it possible to offer subscription-based digital access
 
 ## Can I help?
-Aww, thanks so much!  We're glad you've been enjoying the party and want to add even more to it. Please read our [contributing guidelines](./CONTRIBUTING.md) for guidance on how you can best contribute.
+Aww, thanks so much!  We're glad you've been enjoying Nourish and want to add to it. Please read our [contributing guidelines](./CONTRIBUTING.md) for guidance on how you can best contribute.
 
 (We have a Nourish for Nourish, here's how to chip in)

--- a/SETUP.md
+++ b/SETUP.md
@@ -38,7 +38,7 @@ brew services start postgresql
 1. Run the setup script:
 
  ```
- cd /path/to/nourish.party
+ cd /path/to/nourish
  bin/setup
  ```
 
@@ -48,7 +48,7 @@ brew services start postgresql
 
 ### Run the Application
 ```
-cd /path/to/nourish.party
+cd /path/to/nourish
 bin/serve
 ```
 This starts several processes:

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
-  "name": "nourish.party",
+  "name": "Nourish",
   "repository": "https://github.com/wecohere/nourish.party",
-  "description": "Nourish Party is a community-focused, online payment platform for groups of interdependent creatives.",
+  "description": "Nourish is a community-focused, project-oriened crowd-funding platform for creatives.",
   "keywords": ["payments", "federated", "community"],
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate db:seed"

--- a/app/assets/README.md
+++ b/app/assets/README.md
@@ -4,7 +4,7 @@ Philosophical TL;DR: Like [this (content warning: swears)](http://bettermotherfu
 
 This project has one big frontend goal and one big frontend constraint:
 
-**GOAL**: If someone wants to give a creator who's using nourish.party money, we do not want to get in their way with slow pageloads, buggy Javascript, poor cross-browser support, etc.
+**GOAL**: If someone wants to give a creator who's using Nourish money, we do not want to get in their way with slow pageloads, buggy Javascript, poor cross-browser support, etc.
 
 **CONSTRAINT**: We do not have a crack frontend infrastructure team, we have a bunch of part-time generalists.
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Welcome to nourish.party!</h1>
+<h1>Welcome to Nourish</h1>
 
 <%= render partial: 'projects/summary', collection: projects, as: :project, locals: { heading_level: 2 } %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>NourishParty</title>
+    <title>Nourish</title>
     <%= csrf_meta_tags %>
 
     <%= javascript_pack_tag 'application' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   shared:
     mail:
       greeting: "Hello"
-      signature: "The volunteers at Nourish.Party"
+      signature: "The volunteers at Nourish"
     links:
       browse_projects: "Home"
       pending_projects: "Pending Projects"
@@ -13,7 +13,7 @@ en:
 
   approving_project:
     begin: "Approve"
-    reason_field: "Why do you think this project is a good fit for Nourish.Party?"
+    reason_field: "Why do you think this project is a good fit for Nourish?"
     cancel: "Cancel"
     complete: "Approve"
     success_notification: "You have approved the project %{project_title}"
@@ -26,7 +26,7 @@ en:
 
   rejecting_project:
     begin: "Reject"
-    reason_field: "Why do you think this project is not a good fit for Nourish.Party?"
+    reason_field: "Why do you think this project is not a good fit for Nourish?"
     cancel: "Cancel"
     complete: "Reject"
     success_notification: "You have rejected the project %{project_title}"
@@ -40,7 +40,7 @@ en:
       failed: "We were unable to connect the Slack team. Try again?"
     destroy:
       succeeded: "The connection between Nourish and the Slack team named %{name} was removed."
-      failed: "The connection between Nourish.Party and the Slack team named %{name} was unable to be removed. Try again?"
+      failed: "The connection between Nourish and the Slack team named %{name} was unable to be removed. Try again?"
 
   stripe_connections:
     heading: "Process Payments via Stripe"
@@ -50,16 +50,16 @@ en:
     account_owner_statement_descriptor_explanation: 'Appears on credit card statements as "%{statement_descriptor}"'
     connection_successful: "You successfully connected %{stripe_display_name}"
     connection_failed: "We were unable to connect the stripe account. Try again?"
-    connection_destroyed: "The connection between nourish.party and stripe account named %{stripe_display_name} was removed."
-    connection_destroy_failed: "The connection between nourish.party and the stripe account named %{stripe_display_name} was unable to be removed. Try again?"
+    connection_destroyed: "The connection between Nourish and stripe account named %{stripe_display_name} was removed."
+    connection_destroy_failed: "The connection between Nourish and the stripe account named %{stripe_display_name} was unable to be removed. Try again?"
   project_status_change_mailer:
     approved:
-      subject: "Your project has been approved to receive support on Nourish.Party"
-      preamble: "We're happy to announce that your project has been approved to receive support on Nourish.Party. Staff passed along the following reason:"
+      subject: "Your project has been approved to receive support on Nourish"
+      preamble: "We're happy to announce that your project has been approved to receive support on Nourish. Staff passed along the following reason:"
       conclusion: "We're looking forward to celebrating your project's success and helping you achieve your funding goals!"
     rejected:
-      subject: "We need more information before your project may receive support on Nourish.Party"
-      preamble: "Unfortunately, we're unable to approve your project to receive support on Nourish.Party. Staff passed along the following reason:"
+      subject: "We need more information before your project may receive support on Nourish"
+      preamble: "Unfortunately, we're unable to approve your project to receive support on Nourish. Staff passed along the following reason:"
       conclusion: "If you believe this has been in error, feel free to reply to this email and we'll be in touch."
 
   contributions:

--- a/wp-nourish/readme.txt
+++ b/wp-nourish/readme.txt
@@ -1,22 +1,23 @@
-=== Nourish Party for WordPress ===
+
+=== Nourish for WordPress ===
 Contributors: emdashbuck
 Tags: patreon, stripe, payment, paypal, twitch, mastodon
-Donate link: nourish.party
+Donate link: https://nourish.is/
 Tested up to: 4.9
 Stable tag: trunk
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Connect your Nourish Party to your WordPress site!
+Connect your Nourish to your WordPress site!
 
 == Description ==
-What Nourish Party Is
+What Nourish Is
 
-How Nourish Party interacts with your WordPress site
+How Nourish interacts with your WordPress site
 
-What you can use Nourish Party for
+What you can use Nourish for
 
-Why we\'re offering Nourish Party for free
+Why we\'re offering Nourish for free
 
 == Installation ==
 Info about hooking up the API key and stuff will go here.
@@ -28,4 +29,4 @@ Frequently asked questions will go here once we are asked any!
 0.0.00 Development started.
 
 == Upgrade Notice ==
-There is no pro version of this plugin, but check out nourish.party for fancy extras?
+There is no pro version of this plugin, but check out https://nourish.is for fancy extras?

--- a/wp-nourish/wp-nourish.php
+++ b/wp-nourish/wp-nourish.php
@@ -1,8 +1,8 @@
 <?php
 /*
-Plugin Name:  Nourish Party for WordPress
+Plugin Name:  Nourish for WordPress
 Plugin URI:   https://github.com/wecohere/nourish.party
-Description:  Connect your Nourish Party to your WordPress site!
+Description:  Connect your Nourish to your WordPress site!
 Version:      0.0.00
 Author:       Dash Buck
 Author URI:   https://dashbuck.com/


### PR DESCRIPTION
Part of @Atav1k's suggestions to make the branding more general purpose. If we do a rename of the repository we'll want to update those links too.

